### PR TITLE
DEV-484 Modify: GeneralList, Detail Invalid Initializer

### DIFF
--- a/components/BorderDetail.js
+++ b/components/BorderDetail.js
@@ -5,7 +5,7 @@ import Detail from './GeneralDetail';
 
 const BorderDetail = ({
   headers,
-  columns /* function or keypath */,
+  columns = {} /* function or keypath */,
   entity,
   halfWidth = false,
   className = '',

--- a/components/BorderDetail.js
+++ b/components/BorderDetail.js
@@ -1,11 +1,11 @@
-// 
+//
 import React from 'react';
 import { Button } from 'reactstrap';
 import Detail from './GeneralDetail';
 
 const BorderDetail = ({
   headers,
-  columns = [] /* function or keypath */,
+  columns /* function or keypath */,
   entity,
   halfWidth = false,
   className = '',

--- a/components/GeneralDetail.js
+++ b/components/GeneralDetail.js
@@ -11,7 +11,7 @@ const _defaultTimestampColFunc = (row) => (
   </div>
 );
 
-const GeneralDetail = ({ headers, columns /* function or keypath */, entity, halfWidth = false }) => (
+const GeneralDetail = ({ headers, columns = {} /* function or keypath */, entity, halfWidth = false }) => (
   <dl className='row'>
     {headers.reduce((acc, title, i) => {
       let column;

--- a/components/GeneralDetail.js
+++ b/components/GeneralDetail.js
@@ -1,4 +1,4 @@
-// 
+//
 import React from 'react';
 import moment from 'moment';
 import _ from 'lodash';
@@ -11,12 +11,7 @@ const _defaultTimestampColFunc = (row) => (
   </div>
 );
 
-const GeneralDetail = ({
-  headers,
-  columns = [] /* function or keypath */,
-  entity,
-  halfWidth = false,
-}) => (
+const GeneralDetail = ({ headers, columns /* function or keypath */, entity, halfWidth = false }) => (
   <dl className='row'>
     {headers.reduce((acc, title, i) => {
       let column;

--- a/components/GeneralList.js
+++ b/components/GeneralList.js
@@ -31,8 +31,8 @@ const _defaultSortableHeader = (sortingElements, header) => {
 
 const GeneralList = ({
   headers,
-  columns /* function or keypath */,
-  columnClassNames,
+  columns = {} /* function or keypath */,
+  columnClassNames = {},
   rows,
   prefix,
   sortingElements,

--- a/components/GeneralList.js
+++ b/components/GeneralList.js
@@ -35,7 +35,7 @@ const GeneralList = ({
   columnClassNames = {},
   rows,
   prefix,
-  sortingElements,
+  sortingElements = {},
   optionHeader = _defaultSortableHeader,
   optionColumn = _defaultOptionColFunc,
   ...rest

--- a/components/GeneralList.js
+++ b/components/GeneralList.js
@@ -31,7 +31,7 @@ const _defaultSortableHeader = (sortingElements, header) => {
 
 const GeneralList = ({
   headers,
-  columns = [] /* function or keypath */,
+  columns /* function or keypath */,
   columnClassNames = [],
   rows,
   prefix,

--- a/components/GeneralList.js
+++ b/components/GeneralList.js
@@ -32,7 +32,7 @@ const _defaultSortableHeader = (sortingElements, header) => {
 const GeneralList = ({
   headers,
   columns /* function or keypath */,
-  columnClassNames = [],
+  columnClassNames,
   rows,
   prefix,
   sortingElements,


### PR DESCRIPTION
`GeneralList`의 props `columns`의 default initializer를 변경했습니다.

기존에는 `[]`로 init되어 사용되어있었기에

```jsx
columns={{
    '#': getIndexOfRowFunctor(totalCount, page.current, page.limit),
    ...
}}
```
처럼 object를 넣는 방식이 TS Error를 유발했습니다.

해당 현상을 해결하기 위해 default initializer를 `{}`로 변경하여 해당 `props`에 `array`, `object` 모두 넣는 것이 가능하도록 하였습니다.

[GeneralList.js#80](https://github.com/easi6/cli-common/blob/ed76ff7fac468889e69c743b9a7e3434ee95ec5e/components/GeneralList.js#L80), 
[GeneralList.js#139](https://github.com/easi6/cli-common/blob/ed76ff7fac468889e69c743b9a7e3434ee95ec5e/components/GeneralList.js#L139)

링크에서 확인할 수 있듯이 매번 타입체킹 되어 사용되었기 때문에 사용상에 문제는 없을 것 같습니다.


